### PR TITLE
GOOGLE_LOGIN_SCOPES => GOOGLE_LOGIN_CLIENT_SCOPES; be the same with the ...

### DIFF
--- a/flask_googlelogin.py
+++ b/flask_googlelogin.py
@@ -65,7 +65,7 @@ class GoogleLogin(object):
 
     @property
     def scopes(self):
-        return self.app.config.get('GOOGLE_LOGIN_SCOPES', '')
+        return self.app.config.get('GOOGLE_LOGIN_CLIENT_SCOPES', '')
 
     @property
     def client_id(self):


### PR DESCRIPTION
the doc and source didn't match

doc:
Configuration
Google API
GOOGLE_LOGIN_CLIENT_ID  Client ID (create one at https://code.google.com/apis/console)
GOOGLE_LOGIN_CLIENT_SECRET  Client Secret
GOOGLE_LOGIN_CLIENT_SCOPES  Default scopes
GOOGLE_LOGIN_REDIRECT_URI   Default redirect URI    

source:
return self.app.config.get('GOOGLE_LOGIN_SCOPES', '')
