### PR TITLE
Do not recreate the login_manager in init_app.

### DIFF
--- a/flask_googlelogin.py
+++ b/flask_googlelogin.py
@@ -43,8 +43,6 @@ class GoogleLogin(object):
 
         if login_manager:
             self.login_manager = login_manager
-        else:
-            self.login_manager = LoginManager()
 
         # Check if login manager has been init
         if not hasattr(app, 'login_manager'):


### PR DESCRIPTION
If you recreate the login manager, it is useless to set `user_loader` because it is cleaned on `init_app`.

```
googlelogin = GoogleLogin()

@googlelogin.user_loader
def load_user(user_id):
    return users.get(user_id)

# googlelogin.login_manager.user_callback is load_user

googlelogin.init_app(app)
# googlelogin.login_manager.user_callback is None
```

I wanted to remove the `login_manager` parameter from `init_app` to avoid replacing the already defined `login_manager`, but it will break backward compatibility. This way, at least I can set `user_loader`.

Without this patch, I have to do `googlelogin.init_app(app, googlelogin.login_manager)`, which is an awful workaround.
